### PR TITLE
fix(server): resolve GetEntityCoords error by wrapping with GetPlayerPed

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -57,7 +57,7 @@ RegisterServerEvent('vorp_lumberjack:addItem', function()
 
 	-- check coords of tree
 	local tree_coords = choppingtree
-	local player_coords = GetEntityCoords(_source)
+	local player_coords = GetEntityCoords(GetPlayerPed(_source))
 	local distance = #(tree_coords - player_coords)
 	if distance > 10.0 then
 		return


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
This pull request fixes a runtime error caused by incorrect usage of the GetEntityCoords native on the server side. The function was originally called with _source, which is a player server ID and not a valid entity. This caused an invalid entity error during execution.

The fix wraps the argument in GetPlayerPed(_source) to correctly retrieve the player’s ped entity before passing it to GetEntityCoords, ensuring proper execution and avoiding crashes.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
These changes are proposed to resolve a server-side runtime error caused by incorrect usage of the GetEntityCoords native. Previously, the function was called with a player server ID (_source), which is not a valid entity, leading to a "Tried to access invalid entity" error.

The update ensures that GetEntityCoords receives a valid player ped entity by wrapping _source with GetPlayerPed(_source). This change allows the script to correctly retrieve the player’s coordinates and prevents crashes or unexpected behavior during the lumberjack action logic.

### Explain the necessity of these changes and how they will impact the framework or its users.
This change is necessary to prevent runtime errors that occur when the server attempts to retrieve a player's coordinates using an invalid entity reference. Without this fix, the script can fail during execution, disrupting gameplay and potentially causing instability in the framework.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [X] Tested with latest vorp scripts
- [X] Tested with latest artifacts

## Notes if any
I dont have extra notes.