### PR TITLE
feat(server): add same configs according vorp_mining

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -2,21 +2,22 @@ Config = {}
 
 Lang = "English"
 
-Config.Axe = "hatchet"            -- Item you want to use as an axe, same DB
+Config.Axe = "hatchet"                  -- Item you want to use as an axe, same DB
 
-Config.ChopPromptKey = 0xD9D0E1C0 -- [ SPACE ] Key to press for prompt
+Config.ChopPromptKey = 0xD9D0E1C0       -- [ SPACE ] Key to press for prompt
+Config.CancelChopKey = 0x3B24C470       -- [ F ] Key to Cancel Choppinp
+Config.ChopTreeKey = 0x07B8BEAF         -- [ MOUSE LEFT CLICK ] Key To Chop Tree
 
-Config.CancelChopKey = 0x3B24C470 -- [ F ] Key to Cancel Choppinp
+Config.MinSwing = 1                     -- Min Swings on a Tree
+Config.MaxSwing = 5                     -- Max Swings on a Tree
 
-Config.ChopTreeKey = 0x07B8BEAF   -- [ MOUSE LEFT CLICK ] Key To Chop Tree
+Config.AxeDurabilityThreshold = 20      -- Breakage threshold of the pickaxe
 
-Config.MinSwing = 1
-
-Config.MaxSwing = 5
+Config.AxeBreakChanceMin = 1            -- Lower limit of the probability of the pick breaking
+Config.AxeBreakChanceMax = 3            -- Upper limit of the probability of the pick breaking
 
 -- Lower number is harder
 Config.minDifficulty = 3800
-
 Config.maxDifficulty = 2000
 ---------------------------
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -28,8 +28,8 @@ RegisterServerEvent("vorp_lumberjack:axecheck", function(tree)
 		local description = T.NotifyLabels.descDurabilityTwo .. " " .. durability
 		local metadata = { description = description, durability = durability }
 
-		if durability < 20 then
-			local random = math.random(1, 3)
+		if durability < Config.AxeDurabilityThreshold then
+			local random = math.random(Config.AxeBreakChanceMin, Config.AxeBreakChanceMax)
 			if random == 1 then
 				VorpCore.NotifyObjective(_source, T.NotifyLabels.brokeAxe, 5000)
 				exports.vorp_inventory:subItem(_source, Config.Axe, 1, meta)


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
I added a few configuration options to control pickaxe durability and break chance, similar to the settings in vorp_mining. This makes it easier for server owners to customize how and when pickaxes break.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
These changes are proposed to give server owners more control over pickaxe durability and the chance of it breaking. By adding these config options

### Explain the necessity of these changes and how they will impact the framework or its users.
These changes are necessary to improve customization for server owners. By allowing control over pickaxe durability and break chance, users can better tailor the mining experience to fit their server’s needs. This makes the framework more adaptable and user-friendly without affecting existing functionality.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [X] Tested with latest vorp scripts
- [X] Tested with latest artifacts

## Notes if any
I dont have extra notes
