### PR TITLE
Tree chopping prompts disappear after axe breaks

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -62,6 +62,7 @@ RegisterServerEvent("vorp_lumberjack:axecheck", function(tree)
 				VorpCore.NotifyObjective(_source, T.NotifyLabels.brokeAxe, 5000)
 				exports.vorp_inventory:subItem(_source, Config.Axe, 1, meta)
 				TriggerClientEvent("vorp_lumberjack:noaxe", _source)
+				return
 			else
 				exports.vorp_inventory:setItemMetadata(_source, axe.id, metadata, 1)
 				TriggerClientEvent("vorp_lumberjack:axechecked", _source, choppingtree)


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
I’m fixing a bug that I’ve also encountered on other servers. It’s an easy issue to resolve, but it seems that no one had noticed it before.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
To fix a minor bug that can be easily resolved.

### Explain the necessity of these changes and how they will impact the framework or its users.
I’m not entirely sure how much this impacts the framework itself, but for players, it’s quite annoying to have to relog every time they want to chop trees again. 😄

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [X] Tested with latest vorp scripts
- [X] Tested with latest artifacts


The issue occurred when a player broke their axe the next time they tried to chop a tree, it wouldn’t work, and the chop prompts disappeared.

This happened because, on the server side, even after the axe was removed, the player was still being inserted into the chopping_trees table:

chopping_trees[_source] = { coords = choppingtree, count = 0 }

as if they were still chopping.

Due to the following check:

if chopping_trees[_source] then
    return
end

the resource stopped functioning properly, forcing the player to relog to be able to chop trees again.

After applying the fix, I tested by breaking the axe and attempting to chop again, and everything worked properly.